### PR TITLE
fix device not found issue(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ cp initramfs-init-dropbear /usr/share/mkinitfs/initramfs-init-dropbear
 cp dropbear/unlock_disk /etc/dropbear/
 ```
 
-- Add `dropbear` (and `network` if not present) to `/etc/mkinitfs/mkinitfs.conf` and remove `cryptsetup`
+- Add `dropbear` (and `network` if not present – also `virtio` if network devices are virtualized) to `/etc/mkinitfs/mkinitfs.conf` and remove `cryptsetup`
 
 - Copy a ssh-public-key to `/etc/dropbear/authorized_keys`
 - Optional: Copy `dropbear_*_host_keys` to `/etc/dropbear` if needed, dropbear will generate

--- a/initramfs-init-dropbear
+++ b/initramfs-init-dropbear
@@ -372,7 +372,11 @@ eend 0
 
 if [ -n "$KOPT_dropbear" ]; then
 	configure_ip
-	setup_dropbear || echo "Failed to uncrypt root via ssh"
+	if [ -n "$KOPT_cryptroot" ]; then
+	  # wait for blk device to appear
+	  nlplug-findfs -p /sbin/mdev ${KOPT_debug_init:+-d} ${KOPT_cryptroot}
+	  setup_dropbear || echo "Failed to uncrypt root via ssh"
+	fi
 elif [ -n "$KOPT_cryptroot" ]; then
 	cryptopts="-c ${KOPT_cryptroot}"
 	if [ -n "$KOPT_cryptdm" ]; then


### PR DESCRIPTION
This PR should fix two issues that had been causing me quite a headache for a while now:

- The machine couldn't get an IP: Took me a while, but if your machine uses virtio-devices you need `virtio` additionally to `network` in your `mkinitfs.conf`. Should've been obvious, but I missed it.
- For whatever reason, on my machine `/dev/sdaX` couldn't be found. I first thought this might've been a virtio-issue as well, but adding and loading every remotely relevant looking module didn't help here. Confusingly it _was_ found with the regular `cryptsetup` hook.

Seems like the regular unlocking process utilizes `nlplug-findfs`, which handles calling cryptsetup, but _also_ coldplugs until a device is found, using `mdev`. So I just added a call to `nlplug-findfs` to find `cryptroot` (differing a bit from the way the initramfs-script does it, as here we want to invoke `unlock_disk` and not unlock the cryptdevice directly).