### PR TITLE
'-m' is dropped in recent dropbear

### DIFF
--- a/initramfs-init-dropbear
+++ b/initramfs-init-dropbear
@@ -270,7 +270,7 @@ setup_dropbear() {
 	mkdir /root/.ssh
 	mv /etc/dropbear/authorized_keys /root/.ssh
 
-	dropbear -R -F -E -m -s -j -k -p $port
+	dropbear -R -F -E -s -j -k -p $port
 
 	[ -b /dev/mapper/${KOPT_cryptdm} ] || return 1
 }


### PR DESCRIPTION
Dropbear fails during boot because the `-m`-option seems to have been dropped from dropbear in recent versions. Removing `-m` doesn't seem to have any observable side effects, so it should be fine.